### PR TITLE
Tweak for empty list of ids in GET_MANY

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,7 @@ exports.default = function (apiUrl) {
         break;
       case _reactAdmin.GET_MANY:
         {
+          if (params.ids.length === 0) return { url: null };
           var listId = params.ids.map(function (id) {
             return { id: id };
           });
@@ -203,6 +204,11 @@ exports.default = function (apiUrl) {
         url = _convertDataRequestTo.url,
         options = _convertDataRequestTo.options;
 
+    if (url === null) {
+      return new Promise(function (resolve, reject) {
+        return resolve({ data: [] });
+      });
+    }
     return httpClient(url, options).then(function (response) {
       return convertHTTPResponse(response, type, resource, params);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export default (apiUrl, httpClient = fetchJson) => {
         url = `${apiUrl}/${resource}/${params.id}`;
         break;
       case GET_MANY: {
+        if (params.ids.length === 0) return { url: null }
         const listId = params.ids.map(id => {
           return {id};
         });
@@ -169,7 +170,11 @@ export default (apiUrl, httpClient = fetchJson) => {
       resource,
       params
     );
-    
+    if (url === null) {
+      return new Promise((resolve, reject) =>
+        resolve({ data: [] })
+      );
+    }
     return httpClient(url, options).then(response =>
         convertHTTPResponse(response, type, resource, params)
     );


### PR DESCRIPTION
When loopback receives `where: { or: [] }`, it throws an internal server error. This can happen when the list in a `ReferenceArrayField` is empty.