### PR TITLE
Show loopback 3 errors in react-admin modal

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015"],
+  "presets": ["env", "es2015", "stage-0"],
   "plugins": ["transform-object-rest-spread"]
 }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,23 +1,91 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
-var _reactAdmin = require('react-admin');
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _storage = require('./storage');
 
 var _storage2 = _interopRequireDefault(_storage);
 
+var _reactAdmin = require('react-admin');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = function (url) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
-    options.user = {
-        authenticated: true,
-        token: _storage2.default.load('lbtoken').id
-    };
-    return _reactAdmin.fetchUtils.fetchJson(url, options);
+var fetchJson = function () {
+  var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(url) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var requestHeaders, response, text, o, status, statusText, headers, body, json;
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            requestHeaders = options.headers || new Headers({ Accept: 'application/json' });
+
+            if (!requestHeaders.has('Content-Type') && !(options && options.body && options.body instanceof FormData)) {
+              requestHeaders.set('Content-Type', 'application/json');
+            }
+            if (options.user && options.user.authenticated && options.user.token) {
+              requestHeaders.set('Authorization', options.user.token);
+            }
+            _context.next = 5;
+            return fetch(url, _extends({}, options, { headers: requestHeaders }));
+
+          case 5:
+            response = _context.sent;
+            _context.next = 8;
+            return response.text();
+
+          case 8:
+            text = _context.sent;
+            o = {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+              body: text
+            };
+            status = o.status, statusText = o.statusText, headers = o.headers, body = o.body;
+            json = void 0;
+
+            try {
+              json = JSON.parse(body);
+            } catch (e) {
+              // not json, no big deal
+            }
+
+            if (!(status < 200 || status >= 300)) {
+              _context.next = 15;
+              break;
+            }
+
+            return _context.abrupt('return', Promise.reject(new _reactAdmin.HttpError(json && json.error && json.error.message || statusText, status, json)));
+
+          case 15:
+            return _context.abrupt('return', Promise.resolve({ status: status, headers: headers, body: body, json: json }));
+
+          case 16:
+          case 'end':
+            return _context.stop();
+        }
+      }
+    }, _callee, undefined);
+  }));
+
+  return function fetchJson(_x) {
+    return _ref.apply(this, arguments);
+  };
+}();
+
+exports.default = function (url) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  options.user = {
+    authenticated: true,
+    token: _storage2.default.load('lbtoken').id
+  };
+  return fetchJson(url, options);
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel ./src -d lib --ignore '*.spec.js' --presets babel-preset-es2015"
+    "build": "babel ./src -d lib --ignore '*.spec.js'"
   },
   "files": [
     "*.md",
@@ -16,7 +16,9 @@
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.22.0"
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1"
   },
   "repository": {
     "type": "git",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,10 +1,40 @@
-import { fetchUtils } from 'react-admin';
+import { HttpError } from 'react-admin';
 import storage from './storage';
 
+const fetchJson = async (url, options = {}) => {
+  const requestHeaders = (options.headers || new Headers({ Accept: 'application/json' }));
+  if (!requestHeaders.has('Content-Type') &&
+  !(options && options.body && options.body instanceof FormData)) {
+    requestHeaders.set('Content-Type', 'application/json');
+  }
+  if (options.user && options.user.authenticated && options.user.token) {
+    requestHeaders.set('Authorization', options.user.token);
+  }
+  const response = await fetch(url, { ...options, headers: requestHeaders })
+  const text = await response.text()
+  const o = {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    body: text,
+  };
+  let status = o.status, statusText = o.statusText, headers = o.headers, body = o.body;
+  let json;
+  try {
+    json = JSON.parse(body);
+  } catch (e) {
+    // not json, no big deal
+  }
+  if (status < 200 || status >= 300) {
+    return Promise.reject(new HttpError((json && json.error && json.error.message) || statusText, status, json));
+  }
+  return Promise.resolve({ status: status, headers: headers, body: body, json: json });
+};
+  
 export default (url, options = {}) => {
   options.user = {
       authenticated: true,
       token: storage.load('lbtoken').id
   };
-  return fetchUtils.fetchJson(url, options);
+  return fetchJson(url, options);
 }


### PR DESCRIPTION
Hi, this change shows looback error messages into the react-admin modals instead of the undescriptive header response error.

For example:
![image](https://user-images.githubusercontent.com/165823/56081313-90c6b380-5dd1-11e9-8c5c-72922668a63f.png)

I think this makes more useful this module for loopback users.